### PR TITLE
Extend Grover functions for multiple targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ To run a simulation with 3 qubits searching for the state `|101>`:
 python run_grover.py -n 3 -m 101
 ```
 
+The Python API also supports searching for multiple states by passing a list of
+binary strings to `create_grover_circuit`.
+
 To see all options:
 ```bash
 python run_grover.py --help

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -46,6 +46,13 @@ grover_circuit = create_grover_circuit(num_qubits, target_state, measure=True)
 print(grover_circuit.draw(output='text'))
 ```
 
+You can also provide multiple target states by passing a list of binary strings:
+
+```python
+target_states = ["101", "010"]
+grover_multi = create_grover_circuit(num_qubits, target_states, measure=True)
+```
+
 ## 5. Running the Simulation
 
 You can simulate the circuit using Qiskit's simulators (like `qasm_simulator` for counts or `statevector_simulator` for the state vector).

--- a/run_grover.py
+++ b/run_grover.py
@@ -53,9 +53,9 @@ def run_simulation(n_qubits: int, marked_state_binary: str, shots: int = 1024):
         # Create Grover circuit (measure=True is default in create_grover_circuit now)
         grover_circuit = create_grover_circuit(
             num_qubits=n_qubits,
-            target_state_binary=marked_state_binary,
+            target_states_binary=marked_state_binary,
             iterations=num_iterations,
-            measure=True # Explicitly adding measure gates
+            measure=True  # Explicitly adding measure gates
         )
 
         # print("\nCircuit Diagram:")

--- a/src/grover_circuit.py
+++ b/src/grover_circuit.py
@@ -1,58 +1,74 @@
 import numpy as np
+from typing import Sequence
 from qiskit import QuantumCircuit, ClassicalRegister
 
 # Use explicit relative imports
 from .oracle import create_oracle
 from .diffuser import create_diffuser
 
-def calculate_optimal_iterations(num_qubits: int) -> int:
-    """Calculate the optimal number of Grover iterations for a single target state."""
+def calculate_optimal_iterations(num_qubits: int, num_solutions: int = 1) -> int:
+    """Calculate the optimal number of Grover iterations.
+
+    Supports multiple marked states via ``num_solutions``.
+    """
     if num_qubits < 1:
         return 0
-    if num_qubits == 2: # Special case for N=4 it's known that for N=4 (2 qubits), exactly 1 iteration is optimal.
-        return 1
-    amplitude = np.sqrt(2**num_qubits)
-    # The formula is approx (pi/4) * sqrt(N/M), where N=2^n, M=1
-    iterations = int(np.round((np.pi / 4.0) * amplitude))
-    return max(1, iterations) # Need at least 1 iteration
+    if num_solutions < 1 or num_solutions > 2 ** num_qubits:
+        raise ValueError("num_solutions must be between 1 and 2**num_qubits")
+
+    n_states = 2 ** num_qubits
+    theta = np.arcsin(np.sqrt(num_solutions / n_states))
+    iterations = int(np.round(np.pi / (4 * theta) - 0.5))
+    return max(1, iterations)
 
 def create_grover_circuit(
     num_qubits: int,
-    target_state_binary: str,
+    target_states_binary: str | Sequence[str],
     iterations: int | None = None,
-    measure: bool = True
+    measure: bool = True,
 ) -> QuantumCircuit:
     """Creates the full Grover algorithm circuit.
 
     Args:
         num_qubits: The total number of qubits for the search.
-        target_state_binary: The binary string representing the target state.
+        target_states_binary: A binary string or list of binary strings
+            representing the target state(s).
         iterations: The number of times to apply the Oracle-Diffuser block.
-                    If None, calculates the optimal number for a single target.
+                    If None, calculates the optimal number based on the number
+                    of target states.
         measure: If True, adds measurement gates at the end.
 
     Returns:
         A QuantumCircuit object representing the Grover algorithm.
 
     Raises:
-        ValueError: If num_qubits is less than 1 or target_state_binary length mismatch.
+        ValueError: If num_qubits is less than 1 or any target state has the
+            wrong length.
     """
     if num_qubits < 1:
         raise ValueError("Number of qubits must be at least 1.")
-    if len(target_state_binary) != num_qubits:
-        raise ValueError(
-            f"Length of target_state_binary ({len(target_state_binary)}) "
-            f"must match num_qubits ({num_qubits})."
-        )
+
+    if isinstance(target_states_binary, str):
+        target_states = [target_states_binary]
+    else:
+        target_states = list(target_states_binary)
+
+    if not target_states:
+        raise ValueError("At least one target state must be provided.")
+    for state in target_states:
+        if len(state) != num_qubits:
+            raise ValueError(
+                f"Length of target_state_binary ({len(state)}) must match num_qubits ({num_qubits})."
+            )
 
     # Determine the number of iterations
     if iterations is None:
-        num_iterations = calculate_optimal_iterations(num_qubits)
+        num_iterations = calculate_optimal_iterations(num_qubits, len(target_states))
     else:
         num_iterations = iterations
 
     # Create components
-    oracle = create_oracle(num_qubits, target_state_binary)
+    oracle = create_oracle(num_qubits, target_states)
     diffuser = create_diffuser(num_qubits)
 
     # Create main circuit

--- a/src/oracle.py
+++ b/src/oracle.py
@@ -1,57 +1,74 @@
+from typing import Iterable, Sequence
 from qiskit import QuantumCircuit
 
-def create_oracle(num_qubits: int, target_state_binary: str) -> QuantumCircuit:
-    """Creates an oracle circuit that marks a specific computational basis state.
 
-    Args:
-        num_qubits: The total number of qubits in the circuit.
-        target_state_binary: The binary string representing the target state to mark.
-                             The length must match num_qubits.
-
-    Returns:
-        A QuantumCircuit object representing the oracle.
-
-    Raises:
-        ValueError: If the length of target_state_binary does not match num_qubits.
-    """
+def _single_state_oracle(num_qubits: int, target_state_binary: str) -> QuantumCircuit:
+    """Create an oracle that flips the phase of a single computational basis state."""
     if len(target_state_binary) != num_qubits:
         raise ValueError(
-            f"Length of target_state_binary ({len(target_state_binary)}) "
-            f"must match num_qubits ({num_qubits})."
+            f"Length of target_state_binary ({len(target_state_binary)}) must match num_qubits ({num_qubits})."
         )
 
-    # Create the quantum circuit
-    oracle_circuit = QuantumCircuit(num_qubits, name="Oracle")
+    oracle = QuantumCircuit(num_qubits, name=f"Oracle_{target_state_binary}")
 
-    # Apply X gates to qubits corresponding to '0' in the target state
-    # This flips the state so the multi-controlled Z gate targets |1...1>
-    # REVERSE the string to match Qiskit's little-endian qubit order
+    # Flip qubits corresponding to '0' so the multi-controlled Z targets |1...1>
     reversed_target = target_state_binary[::-1]
-    zero_indices = [i for i, bit in enumerate(reversed_target) if bit == '0']
+    zero_indices = [i for i, bit in enumerate(reversed_target) if bit == "0"]
     if zero_indices:
-        oracle_circuit.x(zero_indices)
+        oracle.x(zero_indices)
 
-    # Apply the multi-controlled Z gate
-    # If num_qubits is 1, apply a Z gate
-    # If num_qubits is 2, apply a CZ gate
-    # Otherwise, use mcx with an auxiliary qubit or mcz if available
     if num_qubits == 1:
-        oracle_circuit.z(0)
+        oracle.z(0)
     elif num_qubits == 2:
-        oracle_circuit.cz(0, 1)
+        oracle.cz(0, 1)
     else:
-        # Use multi-controlled Z gate (MCZ). Qiskit's standard gate library
-        # might require decomposition for > 2 controls depending on the backend.
-        # For simplicity here, we use mcz which might need synthesis/transpilation.
         controls = list(range(num_qubits - 1))
         target = num_qubits - 1
-        # Implement MCZ using H gates and MCX
-        oracle_circuit.h(target)
-        oracle_circuit.mcx(controls, target)
-        oracle_circuit.h(target)
+        oracle.h(target)
+        oracle.mcx(controls, target)
+        oracle.h(target)
 
-    # Apply X gates again to restore the state
     if zero_indices:
-        oracle_circuit.x(zero_indices)
+        oracle.x(zero_indices)
 
-    return oracle_circuit 
+    return oracle
+
+
+def create_oracle(num_qubits: int, target_states_binary: str | Sequence[str]) -> QuantumCircuit:
+    """Create an oracle that marks one or more computational basis states.
+
+    Args:
+        num_qubits: Total number of qubits in the circuit.
+        target_states_binary: Either a single binary string or a sequence of
+            binary strings representing the target state(s). Each string's length
+            must match ``num_qubits``.
+
+    Returns:
+        QuantumCircuit implementing the oracle for all target states.
+
+    Raises:
+        ValueError: If any target state's length does not match ``num_qubits``
+            or if ``target_states_binary`` is empty.
+    """
+
+    if isinstance(target_states_binary, str):
+        target_states: Iterable[str] = [target_states_binary]
+    else:
+        target_states = list(target_states_binary)
+
+    if not target_states:
+        raise ValueError("At least one target state must be provided.")
+
+    for state in target_states:
+        if len(state) != num_qubits:
+            raise ValueError(
+                f"Length of target_state_binary ({len(state)}) must match num_qubits ({num_qubits})."
+            )
+
+    oracle_circuit = QuantumCircuit(num_qubits, name="Oracle")
+
+    for state in target_states:
+        single = _single_state_oracle(num_qubits, state)
+        oracle_circuit.compose(single, range(num_qubits), inplace=True)
+
+    return oracle_circuit

--- a/tests/test_grover_circuit.py
+++ b/tests/test_grover_circuit.py
@@ -2,64 +2,56 @@ import pytest
 from qiskit import transpile
 from qiskit_aer import AerSimulator
 
-# Adjust the import path
 from src.grover_circuit import create_grover_circuit
 
-# Get the QASM simulator backend using AerSimulator
-simulator = AerSimulator(method='automatic')
+# Use AerSimulator for running the circuits
+simulator = AerSimulator(method="automatic")
 
-# Define test parameters (can be parameterized further with pytest.mark.parametrize)
 TEST_CASES = [
-    {"num_qubits": 3, "target_state": "101"},
-    {"num_qubits": 4, "target_state": "1100"},
-    # Add more test cases, perhaps edge cases like 2 qubits
-    {"num_qubits": 2, "target_state": "11"},
+    {"num_qubits": 3, "targets": "101"},
+    {"num_qubits": 4, "targets": "1100"},
+    {"num_qubits": 2, "targets": "11"},
 ]
 
 @pytest.mark.parametrize("case", TEST_CASES)
 def test_grover_finds_target_state(case):
-    """Test if Grover's algorithm finds the correct target state with high probability."""
     num_qubits = case["num_qubits"]
-    target_state = case["target_state"]
-    shots = 1024 # Number of times to run the measurement
+    targets = case["targets"]
+    shots = 1024
 
-    # Create the Grover circuit (using optimal iterations by default)
-    grover_circuit = create_grover_circuit(num_qubits, target_state, measure=True)
+    grover_circuit = create_grover_circuit(num_qubits, targets, measure=True)
 
-    # Transpile for the simulator
     t_circuit = transpile(grover_circuit, simulator)
-
-    # Run the simulation
     job = simulator.run(t_circuit, shots=shots)
     result = job.result()
     counts = result.get_counts(grover_circuit)
 
-    # Find the outcome with the highest count
-    # Note: Qiskit counts keys seem to be big-endian in this setup.
-    # We compare the target_state directly to the key from counts.
-    most_frequent_outcome = max(counts, key=counts.get)
-    # target_state_qiskit_endian = target_state[::-1] # No reversal needed
+    most_frequent = max(counts, key=counts.get)
+    assert most_frequent == targets
+    probability = counts.get(targets, 0) / shots
+    assert probability > 0.7
 
-    # Assert that the most frequent outcome is the target state
-    assert most_frequent_outcome == target_state, \
-        f"Grover did not find target {target_state}. Most frequent key: {most_frequent_outcome}. Counts: {counts}"
 
-    # Optionally, assert that the target state has a high probability
-    # Check the target state key directly in counts dict
-    target_probability = counts.get(target_state, 0) / shots
-    # Theoretical probability isn't always 1, especially for small N or non-optimal iterations
-    # A lower bound check is more robust
-    assert target_probability > 0.7, \
-        f"Probability of target state {target_state} was too low ({target_probability:.3f}). Counts: {counts}"
+def test_grover_multiple_targets():
+    num_qubits = 3
+    targets = ["101", "010"]
+    shots = 1024
+
+    circuit = create_grover_circuit(num_qubits, targets, measure=True)
+    t_circuit = transpile(circuit, simulator)
+    result = simulator.run(t_circuit, shots=shots).result()
+    counts = result.get_counts(circuit)
+
+    prob_sum = sum(counts.get(t, 0) for t in targets) / shots
+    assert prob_sum > 0.7
+    assert all(counts.get(t, 0) > 0 for t in targets)
+
 
 def test_grover_circuit_invalid_input():
-    """Test input validation for the Grover circuit creation."""
-    # Test invalid number of qubits
     with pytest.raises(ValueError, match="Number of qubits must be at least 1"):
         create_grover_circuit(0, "")
 
-    # Test mismatched target state length
     with pytest.raises(ValueError, match="must match num_qubits"):
-        create_grover_circuit(3, "10") # Too short
+        create_grover_circuit(3, "10")
     with pytest.raises(ValueError, match="must match num_qubits"):
-        create_grover_circuit(3, "1011") # Too long 
+        create_grover_circuit(3, "1011")


### PR DESCRIPTION
## Summary
- support lists of marked states in `create_oracle`
- generalize Grover circuit to accept multiple targets and compute optimal iterations
- update CLI wrapper for new argument name
- document multi-target usage
- add tests for multiple targets

